### PR TITLE
l/list-migrations: (optionally) initialize a JDBC driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a simple task for [boot](https://github.com/boot-clj/boot) to generate, 
       -m, --migrate             Run all the migrations not applied so far.
       -r, --rollback            Increase number of migrations to be immediately rolled back.
       -l, --list-migrations     List all migrations to be applied.
+      -c, --driver-class        The JDBC driver class name to initialize.
       
 
 ## Examples
@@ -46,3 +47,13 @@ To simplify those commands you may set task option in build.boot:
      ragtime {:database "jdbc:postgresql://localhost:5432/template1?user=postgres"})
    
 and now, you may omit -d ... option from command line.
+
+## JDBC Driver
+
+If you see an exception like `java.sql.SQLException: No suitable driver found`,
+you must explicitly pass the class name of the JDBC driver you're using.  For
+postgres, this is `org.postgresql.Driver`.
+
+To apply migrations using a specified driver name, you might do:
+
+    boot ragtime -m -c org.postgresql.Driver -d "jdbc:postgresql://localhost:5432/template1?user=postgres"

--- a/src/mbuczko/boot_ragtime.clj
+++ b/src/mbuczko/boot_ragtime.clj
@@ -15,8 +15,9 @@
    g generate  MIGRATION  str  "name of generated migration."
    m migrate              bool "Run all the migrations not applied so far."
    r rollback             int  "number of migrations to be immediately rolled back."
-   l list-migrations      bool "List all migrations to be applied."]
-  
+   l list-migrations      bool "List all migrations to be applied."
+   c driver-class         str  "The JDBC driver class name to initialize."]
+
   (let [worker  (pod/make-pod (update-in (core/get-env) [:dependencies] into rag-deps))
         command (if rollback :rollback (if migrate :migrate))]
 
@@ -32,6 +33,7 @@
       (if-not database
         (util/info "No database set\n")
         (pod/with-eval-in worker
+          ~(if driver-class (Class/forName driver-class))
           (require 'ragtime.main 'ragtime.sql.files)
 
           (if ~list-migrations


### PR DESCRIPTION
This is great, thanks!  I had a small problem that this PR fixes - it provides a way for the user to initialize the JDBC driver inside the ragtime pod.
