### PR TITLE
use with-pre-wrap in ragtime task, added test and bumped boot.core

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,12 @@
 (set-env!
- :source-paths   #{"src"}
+ :source-paths   #{"src" "test"}
  :dependencies '[[org.clojure/clojure "1.6.0" :scope "provided"]
-                 [boot/core "2.0.0-rc8" :scope "provided"]
-                 [adzerk/bootlaces "0.1.11" :scope "test"]])
+                 [boot/core "2.0.0" :scope "test"]
+                 [adzerk/bootlaces "0.1.11" :scope "test"]
+                 [adzerk/boot-test "1.0.4" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all]
+         '[adzerk.boot-test :refer :all]
          '[mbuczko.boot-ragtime :refer [ragtime]])
 
 (def +version+ "0.1.0-SNAPSHOT")
@@ -18,4 +20,5 @@
       :url "https://github.com/mbuczko/boot-ragtime"
       :scm {:url "https://github.com/mbuczko/boot-ragtime"}
       :license {"name" "GNU Lesser General Public License"
-                "url" "http://www.gnu.org/licenses/lgpl.txt"}})
+                "url" "http://www.gnu.org/licenses/lgpl.txt"}}
+ test {:namespaces #{'mbuczko.boot-ragtime.test}})

--- a/test/mbuczko/boot_ragtime/test.clj
+++ b/test/mbuczko/boot_ragtime/test.clj
@@ -1,0 +1,9 @@
+(ns mbuczko.boot-ragtime.test
+  (:require [clojure.test :refer :all]
+            [boot.core :refer :all]
+            [mbuczko.boot-ragtime :refer [ragtime]]))
+
+(deftest ragtime-task-composes
+  []
+  (let [fs (boot.tmpdir.TmpFileSet. nil nil nil)]
+    (is (= fs (((ragtime :list-migrations true) identity) fs)))))


### PR DESCRIPTION
We weren't able to compose `ragtime` with other tasks because it didn't return a middleware; the simple fix was to wrap the body in `with-pre-wrap`.
