### PR TITLE
Add option to specify migrations directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This is a simple task for [boot](https://github.com/boot-clj/boot) to generate, 
     Apply/rollback ragtime migrations
 
     Options:
-      -h, --help                Print this help info.
-      -d, --database DATABASE   Set database jdbc url to DATABASE.
-      -g, --generate MIGRATION  Set name of generated migration to MIGRATION.
-      -m, --migrate             Run all the migrations not applied so far.
-      -r, --rollback            Increase number of migrations to be immediately rolled back.
-      -l, --list-migrations     List all migrations to be applied.
-      -c, --driver-class        The JDBC driver class name to initialize.
+      -h, --help                 Print this help info.
+      -d, --database DATABASE    Set database jdbc url to DATABASE.
+      -g, --generate MIGRATION   Set name of generated migration to MIGRATION.
+      -m, --migrate              Run all the migrations not applied so far.
+      -r, --rollback             Increase number of migrations to be immediately rolled back.
+      -l, --list-migrations      List all migrations to be applied.
+      -c, --driver-class         The JDBC driver class name to initialize.
+          --directory DIRECTORY  Set directory to store migrations in to DIRECTORY.
       
 
 ## Examples


### PR DESCRIPTION
I added an option to specify the directory where migrations are kept so that the user can override the default "migrations/". This allows me to convert from a Leiningen project using lein-ragtime where the migrations were kept in "resources/migrations". I believe that this might be a somewhat common scenario.
