### PR TITLE
Add `require` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This is a simple task for [boot](https://github.com/boot-clj/boot) to generate, 
       -l, --list-migrations      List all migrations to be applied.
       -c, --driver-class         The JDBC driver class name to initialize.
           --directory DIRECTORY  Set directory to store migrations in to DIRECTORY.
-      
+
+To use the ragtime task, require it in `build.boot`:
+
+    (require '[mbuczko.boot-ragtime :refer [ragtime]])
 
 ## Examples
 


### PR DESCRIPTION
I noticed that there wasn't any information regarding how to use the ragtime task, and had to search through the repo for a usage example, so I put it on the README.
