### PR TITLE
Allow ragtime version to be specified as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ This is a simple task for [boot](https://github.com/boot-clj/boot) to generate, 
     Apply/rollback ragtime migrations
 
     Options:
-      -h, --help                 Print this help info.
-      -d, --database DATABASE    Set database jdbc url to DATABASE.
-      -g, --generate MIGRATION   Set name of generated migration to MIGRATION.
-      -m, --migrate              Run all the migrations not applied so far.
-      -r, --rollback             Increase number of migrations to be immediately rolled back.
-      -l, --list-migrations      List all migrations to be applied.
-      -c, --driver-class         The JDBC driver class name to initialize.
-          --directory DIRECTORY  Set directory to store migrations in to DIRECTORY.
+      -h, --help                     Print this help info.
+      -d, --database DATABASE        DATABASE sets database jdbc url.
+      -g, --generate MIGRATION       MIGRATION sets name of generated migration.
+      -m, --migrate                  Run all the migrations not applied so far.
+      -r, --rollback                 Increase number of migrations to be immediately rolled back.
+      -l, --list-migrations          List all migrations to be applied.
+      -c, --driver-class DRIVER      DRIVER sets the JDBC driver class name to initialize.
+          --directory DIRECTORY      DIRECTORY sets directory to store migrations in.
+          --ragtime-version VERSION  VERSION sets the version of ragtime to use. default: 0.7.2.
 
 To use the ragtime task, require it in `build.boot`:
 
@@ -61,3 +62,8 @@ postgres, this is `org.postgresql.Driver`.
 To apply migrations using a specified driver name, you might do:
 
     boot ragtime -m -c org.postgresql.Driver -d "jdbc:postgresql://localhost:5432/template1?user=postgres"
+
+## Ragtime Version
+
+Currently the default version of ragtime that is used is `0.7.2`. If you need to use another version, this
+can be specified using the `ragtime-version` option.

--- a/src/mbuczko/boot_ragtime.clj
+++ b/src/mbuczko/boot_ragtime.clj
@@ -5,21 +5,22 @@
    [boot.core   :as core]
    [boot.util   :as util]))
 
-(def ^:private rag-deps '[[ragtime/ragtime "0.5.2"]])
 
 (core/deftask ragtime
   "Apply/rollback ragtime migrations"
-  [d database  DATABASE   str  "database jdbc url"
-   g generate  MIGRATION  str  "name of generated migration."
-   m migrate              bool "Run all the migrations not applied so far."
-   r rollback             int  "number of migrations to be immediately rolled back."
-   l list-migrations      bool "List all migrations to be applied."
-   c driver-class  DRIVER str  "The JDBC driver class name to initialize."
-   _ directory DIRECTORY  str  "directory to store migrations in."]
+  [d database  DATABASE      str  "database jdbc url"
+   g generate  MIGRATION     str  "name of generated migration."
+   m migrate                 bool "Run all the migrations not applied so far."
+   r rollback                int  "number of migrations to be immediately rolled back."
+   l list-migrations         bool "List all migrations to be applied."
+   c driver-class  DRIVER    str  "The JDBC driver class name to initialize."
+   _ directory DIRECTORY     str  "directory to store migrations in."
+   _ ragtime-version VERSION str  "The version of ragtime to use. default: 0.7.2"]
 
-  (let [worker  (pod/make-pod (update-in (core/get-env) [:dependencies] into rag-deps))
+  (let [worker  (pod/make-pod (update-in (core/get-env) [:dependencies] into [['ragtime/ragtime ragtime-version]]))
         command (if rollback :rollback (if migrate :migrate))
-        migrations-dir (or directory "migrations")]
+        migrations-dir (or directory "migrations")
+        ragtime-version (or ragtime-version "0.7.2")]
 
     (core/with-pre-wrap [fs]
       (if generate


### PR DESCRIPTION
This bumps the default version from `0.5.2` to `0.7.2`.
The motivating cause for this change is that older versions
of `ragtime` do not work with newer versions of `clojure.java.jdbc`.